### PR TITLE
Rockspec

### DIFF
--- a/rockspecs/mongrel2-lua-scm-0.rockspec
+++ b/rockspecs/mongrel2-lua-scm-0.rockspec
@@ -10,7 +10,8 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
-   "lua-zmq"
+   "lua-zmq",
+   "luajson"
 }
 
 build = {

--- a/rockspecs/mongrel2-lua-scm-0.rockspec
+++ b/rockspecs/mongrel2-lua-scm-0.rockspec
@@ -1,0 +1,26 @@
+package = "mongrel2-lua"
+version = "scm-0"
+source = {
+   url = "git://github.com/jsimmons/mongrel2-lua.git",
+}
+description = {
+   summary = "A mongrel2 backend handler for Lua.",
+   license = "MIT/X11",
+   homepage = "http://github.com/jsimmons/mongrel2-lua"
+}
+dependencies = {
+   "lua >= 5.1",
+   "lua-zmq"
+}
+
+build = {
+  type = "none",
+  install = {
+    lua = {
+      ["mongrel2.lua"]        = "init.lua",
+      ["mongrel2.connection"] = "connection.lua",
+      ["mongrel2.request"]    = "request.lua",
+      ["mongrel2.util"]       = "util.lua"
+    }
+  }
+}


### PR DESCRIPTION
This adds an scm rockspec to make it easier to install Mongrel2-Lua. Once things settle down it would be nice to add a versioned rockspec, but this should help for now.

It depends on the rock for ZMQ which I just created; I sent a pull request to its author as well. Hopefully both of you will be willing to add and maintain these so that installing the Lua support for Mongrel2 will eventually be as easy as:

```
luarocks install mongrel2
```

If you want any help maintaining Luarocks support I'm definitely more than happy to do it.
