### PR TITLE
Make read and write tables consistent

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -291,7 +291,12 @@ function read(db_file)
         table.insert(servers, server)
     end
 
+    local settings = {}
+    for _, setting in pairs(db_select(db, 'setting')) do
+        table.insert(settings, {key=setting.key, value=setting.value})
+    end
+
     db:close()
 
-    return servers
+    return {servers = servers; settings = settings}
 end


### PR DESCRIPTION
Read settings table and include in generated Lua table to provide for consistency between the table generated on a read and table expected for writes.
