### PR TITLE
Make output read table and expected input write table consistent -- added

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -291,7 +291,12 @@ function read(db_file)
         table.insert(servers, server)
     end
 
+    local settings = {}
+    for _, setting in pairs(db_select(db, 'setting')) do
+        table.insert(settings, {key=setting.key, value=setting.value})
+    end
+
     db:close()
 
-    return servers
+    return {servers = servers, settings = settings}
 end


### PR DESCRIPTION
Make output read table and expected input write table consistent -- added settings data to output table.  Note: I believe this change will need to be coordinated with Tir such that it will continue to load config files properly.  Confirming with Zed...
